### PR TITLE
fix: correct Square punctuation comment

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -6,7 +6,7 @@
   font-family: Inter, sans-serif;
   font-feature-settings: "liga" 1, "calt" 1,
     /* Contextual Alternates */ "dlig" 1, /* Discretionary Ligatures */ "ss07" 1,
-    /* fSquare punctuation */ "ss08" 1, /* Square quotes */ "zero" 1,
+    /* Square punctuation */ "ss08" 1, /* Square quotes */ "zero" 1,
     /* Slashed zero */ "tnum" 1, /* Tabular numbers */ "cv03" 1,
     /* Open six */ "cv04" 1, /* Open nine */ "cv01" 1,
     /* Alternate one */ "cv09", /* Flat-top three */ "cv02" 1; /* Open 4 */


### PR DESCRIPTION
## Summary
- fix the comment for square punctuation in global CSS

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851a402dd508320bf669aa36b004fd6