### PR TITLE
Fix ProjectOne image class

### DIFF
--- a/src/components/landing/ProjectOne.astro
+++ b/src/components/landing/ProjectOne.astro
@@ -9,7 +9,7 @@ import gpastorhallLINKS from "../../images/gpastorhallLINKS.png";
     <Image
       src={gpastorhallLINKS}
       alt="#_"
-      class="rounded-2xl object-coverh-64 w-full lg:h-auto"
+      class="rounded-2xl object-cover h-64 w-full lg:h-auto"
     />
   </div>
   <!--


### PR DESCRIPTION
## Summary
- fix object-cover CSS class name in ProjectOne component

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851a45ad4d08320b03d7f937e28a981