### PR TITLE
Add homepage title test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Run tests
+        run: npm test
+
       - name: Build Astro project
         run: npm run build
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",
-    "preview": "astro preview"
+    "preview": "astro preview",
+    "test": "npm run build && node tests/homepage.test.js"
   },
   "devDependencies": {
     "@astrojs/sitemap": "^3.2.1",

--- a/tests/homepage.test.js
+++ b/tests/homepage.test.js
@@ -1,0 +1,24 @@
+const path = require('path');
+const fs = require('fs');
+const puppeteer = require('puppeteer');
+
+(async () => {
+  const indexPath = path.join(__dirname, '../dist/index.html');
+  if (!fs.existsSync(indexPath)) {
+    console.error(`Built file not found: ${indexPath}`);
+    process.exit(1);
+  }
+
+  const browser = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox', '--disable-setuid-sandbox'] });
+  const page = await browser.newPage();
+  await page.goto('file://' + indexPath);
+  const title = await page.title();
+  await browser.close();
+
+  if (title !== 'Gregory Pastor-Hall | Student and Tinkerer') {
+    console.error(`Unexpected title: ${title}`);
+    process.exit(1);
+  }
+
+  console.log('Homepage title verified successfully');
+})();


### PR DESCRIPTION
## Summary
- add a Puppeteer test for the built homepage title
- wire `npm test` to run before the build step in CI
- include a `test` npm script to build then run the test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851a466425883209e85ef815b72f3dd