### PR TITLE
Add homepage test and run in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Build Astro project
         run: npm run build
 
+      - name: Run tests
+        run: npm test
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",
-    "preview": "astro preview"
+    "preview": "astro preview",
+    "test": "node tests/homepage.test.js"
   },
   "devDependencies": {
     "@astrojs/sitemap": "^3.2.1",

--- a/tests/homepage.test.js
+++ b/tests/homepage.test.js
@@ -1,0 +1,8 @@
+const fs = require('fs');
+const path = require('path');
+const indexPath = path.join(__dirname, '..', 'dist', 'index.html');
+if (!fs.existsSync(indexPath)) {
+  console.error('Homepage not built: ' + indexPath + ' missing');
+  process.exit(1);
+}
+console.log('Homepage exists');


### PR DESCRIPTION
## Summary
- add a minimal homepage test
- add `test` script in package.json
- run the test after building in CI

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68699f06bbc48320a83aed7f381999cc