### PR TITLE
Update test file and CI artifact action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,11 @@ jobs:
       - name: Build Astro project
         run: npm run build
 
+      - name: Run tests
+        run: npm test
+
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",
-    "preview": "astro preview"
+    "preview": "astro preview",
+    "test": "node tests/home.test.js"
   },
   "devDependencies": {
     "@astrojs/sitemap": "^3.2.1",

--- a/tests/home.test.js
+++ b/tests/home.test.js
@@ -1,0 +1,10 @@
+const fs = require('fs');
+const path = require('path');
+const indexPath = path.join(__dirname, '..', 'dist', 'index.html');
+if (!fs.existsSync(indexPath)) {
+  console.error('Homepage not built: ' + indexPath + ' missing');
+  process.exit(1);
+}
+console.log('Homepage exists');
+const contents = fs.readFileSync(indexPath, 'utf8');
+console.log(contents);


### PR DESCRIPTION
## Summary
- rename homepage.test.js to home.test.js
- print file contents when the homepage test passes
- reference new home.test.js in package.json
- use `actions/upload-artifact@v4` in CI

## Testing
- `npm test` *(fails: Homepage not built)*
- `npm run build` *(fails: astro not found)*


------
https://chatgpt.com/codex/tasks/task_e_68699f06bbc48320a83aed7f381999cc