### PR TITLE
Fix timeline page redirect to long embedded URL

### DIFF
--- a/src/pages/timeline/index.astro
+++ b/src/pages/timeline/index.astro
@@ -14,15 +14,15 @@ const timeURL = "https://gpx.studio/embed?options=%7B%22token%22%3A%22pk.eyJ1Ijo
       }
     </style>
 
-    <script>
-      window.location.assign("{{ timeURL }}");
+    <script define:vars={{ timeURL }}>
+      window.location.assign(timeURL);
     </script>
   </head>
 
   <body>
     <p>
       If the Timeline does not open automatically,
-      <a href="{{ timeURL }}">click here to open it</a>.
+      <a href={timeURL}>click here to open it</a>.
     </p>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- The timeline page used a literal template placeholder instead of the configured long URL, which prevented the automatic redirect and fallback link from navigating to the intended external timeline.

### Description
- Update `src/pages/timeline/index.astro` to use the actual `timeURL` variable in the inline script (added `define:vars={{ timeURL }}`) and in the fallback anchor (`<a href={timeURL}>`), so both automatic and manual navigation use the long embedded URL.

### Testing
- Ran `npm run build`; the build initially failed with a server-side template syntax error before the change and completed successfully after the fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699928d8ec008320873e2213833c3f1f)